### PR TITLE
Add Support for openreview.net PDF URLs

### DIFF
--- a/src/scrapers/webcontent-pdfurl-entry-scraper.ts
+++ b/src/scrapers/webcontent-pdfurl-entry-scraper.ts
@@ -24,6 +24,10 @@ export class WebcontentPDFURLEntryScraper extends AbstractEntryScraper {
       return false;
     }
     const urlRegExp = new RegExp(".*.pdf$");
+    // Special case for openreview.net (openreview.net/pdf?id=...)
+    if (payload.value.url.includes("openreview.net/pdf?id=")) {
+      return true;
+    }
     return urlRegExp.test(payload.value.url);
   }
 


### PR DESCRIPTION
This pull request includes a small but significant change to the `WebcontentPDFURLEntryScraper` class. The change adds a special case to handle URLs from `openreview.net` that contain PDFs.

* [`src/scrapers/webcontent-pdfurl-entry-scraper.ts`](diffhunk://#diff-5f3a8878c63358a287f1a82db993b1d5ed095c65bf2201aad660079b64d4270fR27-R30): Added a condition to return `true` for URLs from `openreview.net` that include `pdf?id=` in their query string.